### PR TITLE
Styling/prompt box

### DIFF
--- a/src/components/common/PromptBox/PromptBoxContainer.tsx
+++ b/src/components/common/PromptBox/PromptBoxContainer.tsx
@@ -34,8 +34,8 @@ const PromptBoxContainer = ({
     }
   }, []);
 
-  return promptState && currentRumble ? (
-    <RenderPromptBox prompt={promptState} rumble={currentRumble} />
+  return promptState ? (
+    <RenderPromptBox prompt={promptState} endTime={currentRumble?.end_time} />
   ) : error ? (
     <CouldNotLoad error={error} />
   ) : (

--- a/src/components/common/PromptBox/PromptBoxContainer.tsx
+++ b/src/components/common/PromptBox/PromptBoxContainer.tsx
@@ -3,22 +3,25 @@ import { useRecoilValue } from 'recoil';
 import { Prompts } from '../../../api';
 import { current } from '../../../state';
 import { CouldNotLoad } from '../CouldNotLoad';
+import { Loader } from '../Loader';
 import RenderPromptBox from './RenderPromptBox';
 
 /**
  * PromptBoxContainer will run a useEffect to check for the specific Rumbles prompt.
  */
 
-const PromptBoxContainer = (): React.ReactElement => {
+const PromptBoxContainer = ({
+  prompt,
+}: IPromptBoxContainerProps): React.ReactElement => {
   const currentRumble = useRecoilValue(current.rumble);
-  const [prompt, setPrompt] = useState<string>();
+  const [promptState, setPrompt] = useState<string | undefined>(prompt);
   const [error, setError] = useState<null | string>(null);
 
   /**
    * This useEffect will run every where the PromptBox common component renders in order to pull the prompt related to that page. Whether we are in the student or teacher view.
    */
   useEffect(() => {
-    if (currentRumble) {
+    if (currentRumble && !prompt) {
       Prompts.getPromptById(currentRumble.promptId)
         .then((data) => {
           console.log('Current Prompt: ', data);
@@ -31,15 +34,17 @@ const PromptBoxContainer = (): React.ReactElement => {
     }
   }, []);
 
-  return prompt ? (
-    <RenderPromptBox prompt={prompt} />
+  return promptState && currentRumble ? (
+    <RenderPromptBox prompt={promptState} rumble={currentRumble} />
   ) : error ? (
     <CouldNotLoad error={error} />
   ) : (
-    <>
-      <p>Loading Prompt...</p>
-    </>
+    <Loader message="Loading prompt" />
   );
 };
+
+interface IPromptBoxContainerProps {
+  prompt?: string;
+}
 
 export default PromptBoxContainer;

--- a/src/components/common/PromptBox/RenderPromptBox.tsx
+++ b/src/components/common/PromptBox/RenderPromptBox.tsx
@@ -1,4 +1,6 @@
-import React from 'react';
+import { DateTime } from 'luxon';
+import React, { useMemo } from 'react';
+import { Rumbles } from '../../../api';
 
 /**
  * If a student makes it into a rumble there will be a prompt and countdown timer.
@@ -8,30 +10,52 @@ import React from 'react';
 
 const RenderPromptBox = ({
   prompt,
+  rumble,
 }: IRenderPromptBoxProps): React.ReactElement => {
+  const [date, weekday] = useFormatDate(`${rumble.end_time}`);
+  // const [date, weekday] = useFormatDate('');
+
   return (
-    <div className="prompt-box">
-      <div className="prompt-and-timer">
-        {prompt ? (
-          // If there is a prompt then load in the message "Today's Prompt"
-          <>
+    <div className="prompt-info-wrapper">
+      <div className="prompt-info-container">
+        <div className="prompt-info-content">
+          {date && weekday && (
+            <div className="end-time-large">
+              <div className="date">{date}</div>
+              <div className="day">{weekday}</div>
+            </div>
+          )}
+          <div className="prompt-text">
             <h2>Prompt</h2>
+            {date && weekday && (
+              <div className="end-time-small">
+                {date} {weekday}
+              </div>
+            )}
             <p>{prompt}</p>
-          </>
-        ) : (
-          // Since prompts are not closing ever we are going to display today's prompt at
-          <>
-            <p>Loading Prompt...</p>
-          </>
-        )}
-        <p className="countdown-display">Time Left to Submit HERE!</p>
+          </div>
+        </div>
       </div>
     </div>
   );
 };
 
+const useFormatDate = (
+  date: string | undefined,
+): [date: string | undefined, weekday: string | undefined] => {
+  const luxonDate = useMemo(() => DateTime.fromISO(date || ''), [date]);
+
+  return luxonDate.isValid
+    ? [
+        luxonDate.toLocaleString(DateTime.DATE_SHORT),
+        luxonDate.toLocaleString({ weekday: 'long' }),
+      ]
+    : [undefined, undefined];
+};
+
 interface IRenderPromptBoxProps {
   prompt: string;
+  rumble: Rumbles.IRumbleWithSectionInfo;
 }
 
 export default RenderPromptBox;

--- a/src/components/common/PromptBox/RenderPromptBox.tsx
+++ b/src/components/common/PromptBox/RenderPromptBox.tsx
@@ -1,6 +1,5 @@
 import { DateTime } from 'luxon';
 import React, { useMemo } from 'react';
-import { Rumbles } from '../../../api';
 
 /**
  * If a student makes it into a rumble there will be a prompt and countdown timer.
@@ -10,9 +9,9 @@ import { Rumbles } from '../../../api';
 
 const RenderPromptBox = ({
   prompt,
-  rumble,
+  endTime,
 }: IRenderPromptBoxProps): React.ReactElement => {
-  const [date, weekday] = useFormatDate(`${rumble.end_time}`);
+  const [date, weekday] = useFormatDate(`${endTime || ''}`);
   // const [date, weekday] = useFormatDate('');
 
   return (
@@ -55,7 +54,7 @@ const useFormatDate = (
 
 interface IRenderPromptBoxProps {
   prompt: string;
-  rumble: Rumbles.IRumbleWithSectionInfo;
+  endTime?: Date;
 }
 
 export default RenderPromptBox;

--- a/src/components/pages/TeacherDashboard/TeacherViewRumble/RenderTeacherViewRumble.tsx
+++ b/src/components/pages/TeacherDashboard/TeacherViewRumble/RenderTeacherViewRumble.tsx
@@ -1,7 +1,6 @@
-import { DateTime } from 'luxon';
-import React, { useMemo } from 'react';
+import React from 'react';
 import { Rumbles, Sections } from '../../../../api';
-import { SectionInfo } from '../../../common/SectionInfo';
+import { PromptBox, SectionInfo } from '../../../common';
 import { RumbleStudentList } from './RumbleStudentList';
 
 const RenderTeacherViewRumble = ({
@@ -11,38 +10,10 @@ const RenderTeacherViewRumble = ({
 }: IRenderTeacherViewRumbleProps): React.ReactElement => {
   return (
     <div className="teacher-view-rumble">
-      <div className="prompt-info-wrapper">
-        <div className="prompt-info-container">
-          {rumble.end_time ? (
-            <div className="rumble-time">
-              <div>{formatDate(`${rumble.end_time}`)}</div>
-            </div>
-          ) : (
-            <div className="rumble-closed">
-              <p>Rumble Not Open</p>
-            </div>
-          )}
-          <div className="prompt-text">
-            <h2>Prompt</h2>
-            <p>{prompt}</p>
-          </div>
-        </div>
-      </div>
+      <PromptBox prompt={prompt} />
       <SectionInfo section={section} />
       <RumbleStudentList section={section} rumble={rumble} />
     </div>
-  );
-};
-
-const formatDate = (date: string): React.ReactNode => {
-  const luxonDate = useMemo(() => DateTime.fromISO(date), [date]);
-  return (
-    <>
-      <div className="date">
-        {luxonDate.toLocaleString(DateTime.DATE_SHORT)}
-      </div>
-      <div className="day">{luxonDate.toLocaleString({ weekday: 'long' })}</div>
-    </>
   );
 };
 

--- a/src/styles/components/common/promptBox.scss
+++ b/src/styles/components/common/promptBox.scss
@@ -1,0 +1,51 @@
+.prompt-info-wrapper {
+  .prompt-info-container {
+    @include wrapped-container();
+    background-color: $w-grey-10;
+    border-radius: 1.6rem;
+    padding: 1.6rem;
+    @include bp(tablet) {
+      padding: 3rem 1.6rem;
+    }
+    .prompt-info-content {
+      @include wrapped-container(900px);
+      display: flex;
+      flex-flow: row nowrap;
+      align-items: center;
+      .end-time-large {
+        display: none;
+        @include bp(mid) {
+          display: block;
+          width: 30%;
+        }
+        font-size: 1.6rem;
+        line-height: 2rem;
+        font-weight: 600;
+        color: $c-grey-70;
+      }
+      .prompt-text {
+        h2 {
+          font-size: 2rem;
+          color: $w-grey-50;
+          font-weight: 700;
+          margin-bottom: 1rem;
+        }
+        .end-time-small {
+          @include bp(mid) {
+            display: none;
+          }
+          font-size: 1.6rem;
+          color: $c-grey-70;
+          font-weight: 600;
+          margin-bottom: 1.6rem;
+        }
+        p {
+          font-size: 1.4rem;
+          line-height: 2rem;
+          color: $c-grey-80;
+        }
+      }
+    }
+  }
+  margin: 1rem;
+}

--- a/src/styles/components/pages/teacherDashboard/teacherDashboard.scss
+++ b/src/styles/components/pages/teacherDashboard/teacherDashboard.scss
@@ -13,3 +13,4 @@
 @import './teacherViewSectionPage/teacherViewSection.scss';
 @import './teacherViewRumblePage/teacherViewRumble.scss';
 @import './teacherDashboardStudentList.scss';
+@import './teacherViewSubmission.scss';

--- a/src/styles/components/pages/teacherDashboard/teacherViewRumblePage/teacherViewRumble.scss
+++ b/src/styles/components/pages/teacherDashboard/teacherViewRumblePage/teacherViewRumble.scss
@@ -1,12 +1,3 @@
 .teacher-view-rumble {
   @import './teacherRumbleStudentList.scss';
-  .prompt-info-wrapper {
-    .prompt-info-container {
-      @include wrapped-container();
-      background-color: $w-grey-10;
-      padding: 1.6rem;
-      border-radius: 1.6rem;
-    }
-    margin: 1rem;
-  }
 }

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -26,3 +26,4 @@
 @import './components/common/checkbboxGroup.scss';
 @import './components/common/loader.scss';
 @import './components/common/sectionInfo.scss';
+@import './components/common/promptBox.scss';


### PR DESCRIPTION
# Prompt Box Updates

Styled the prompt box and organized the data. Now allows devs to pass in a prompt if the prompt has already been loaded elsewhere, but will fetch it with an API call if it is not passed in. Scales nicely across all devices. Also adds a custom use hook to get formatted time strings just for funsies.

Edit: `PromptBox` will now work correctly if a current rumble is not set <3
