### PR TITLE
Bugfix/stuck-on-loading

### DIFF
--- a/src/api/Students/students.ts
+++ b/src/api/Students/students.ts
@@ -27,5 +27,5 @@ export const getSubForRumble = async (
   const { data } = await axiosWithAuth().get(
     `/api/rumble/rumbles/${rumbleId}/students/${studentId}`,
   );
-  return data;
+  return data !== '' ? data : undefined;
 };


### PR DESCRIPTION
Checks for empty string and sets to undefined. Allows loading to be set to false and redirect to occur.

# Feature Title

Fixes bug that prevented the student from continuing past the loading page when a rumble had been started. Student could not reach the `StudentSubmissionPage`
