### PR TITLE
Refactor/student rumble redirect clean up

### DIFF
--- a/src/components/pages/StudentDashboard/StudentViewRumble/StudentRumbleRedirect.tsx
+++ b/src/components/pages/StudentDashboard/StudentViewRumble/StudentRumbleRedirect.tsx
@@ -34,6 +34,9 @@ const StudentRumbleRedirect = ({
         .catch((err) => {
           console.log({ err });
           // setError('There is no submission for this Rumble.');
+        })
+        .finally(() => {
+          setLoading(false);
         });
     }
     return () => setSubmission(undefined);
@@ -55,6 +58,9 @@ const StudentRumbleRedirect = ({
         })
         .catch((err) => {
           console.log({ err });
+        })
+        .finally(() => {
+          setLoading(false);
         });
     }
   }, [submission]);

--- a/src/components/pages/StudentDashboard/StudentViewRumble/StudentRumbleRedirect.tsx
+++ b/src/components/pages/StudentDashboard/StudentViewRumble/StudentRumbleRedirect.tsx
@@ -1,4 +1,3 @@
-import { DateTime } from 'luxon';
 import React, { useEffect, useState } from 'react';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { Feedback, Rumbles, Sections, Students } from '../../../../api';
@@ -8,7 +7,6 @@ import { PastRumbleDetails, PeerFeedbackPage } from './StudentRumblePages';
 import { StudentSubmissionPage } from './StudentRumblePages/';
 
 const StudentRumbleRedirect = ({
-  endTime,
   rumble,
   section,
 }: IStudentRumbleRedirectProps): React.ReactElement => {
@@ -16,19 +14,14 @@ const StudentRumbleRedirect = ({
   const user = useRecoilValue(auth.user);
   // The user's submission for the rumble they clicked on
   const [submission, setSubmission] = useRecoilState(current.sub);
-  // Feedback given TO the user's submission
-  const [feedbackForSub, setFeedbackForSub] = useRecoilState(
-    current.feedbackForSubmission,
-  );
   // Whether or not the user has given feedback to others yet
   const [feedbackComplete, setFeedbackComplete] = useState<boolean>();
-
-  const [error, setError] = useState<string>();
   const [loading, setLoading] = useState(true);
 
   // This useEffect is loading the current user's submission for the rumble
   useEffect(() => {
     if (rumble && user && !submission) {
+      setLoading(true);
       Students.getSubForRumble(rumble.id, user.id)
         .then((res) => {
           console.log('subs for rumble', { res });
@@ -40,7 +33,7 @@ const StudentRumbleRedirect = ({
         })
         .catch((err) => {
           console.log({ err });
-          setError('There is no submission for this Rumble.');
+          // setError('There is no submission for this Rumble.');
         });
     }
     return () => setSubmission(undefined);
@@ -49,6 +42,7 @@ const StudentRumbleRedirect = ({
   // This useEffect get the current user's feedback for OTHER submissions in the rumble
   useEffect(() => {
     if (submission && user) {
+      setLoading(true);
       Feedback.checkIfHasSubmittedFeedback({
         rumbleId: rumble.id,
         studentId: user.id,
@@ -58,22 +52,6 @@ const StudentRumbleRedirect = ({
           // If the user has not submitted feedback, stop loading and display feedback form
           if (res === false) setLoading(false);
           setFeedbackComplete(res);
-        })
-        .catch((err) => {
-          console.log({ err });
-        });
-    }
-  }, [submission]);
-
-  //
-  useEffect(() => {
-    if (submission) {
-      // When submission is successfully set,
-      Feedback.getSubmissionFeedback(submission.id)
-        .then((res) => {
-          console.log('sub feedbac', { res });
-          setFeedbackForSub(res);
-          setLoading(false);
         })
         .catch((err) => {
           console.log({ err });
@@ -98,8 +76,5 @@ interface IStudentRumbleRedirectProps {
   section: Sections.ISectionWithRumbles;
   endTime: Date;
 }
-
-const isRumbleEnded = (endTime: string) =>
-  DateTime.fromISO(endTime) <= DateTime.now();
 
 export default StudentRumbleRedirect;


### PR DESCRIPTION
Cleans up `StudentRumbleRedirect.tsx` by 
- Removing a redundant `UseEffect` for an API call to `Feedback.getSubmissionFeedback(submission.id)` that is already happening in `FeedbackContainer.tsx`
- Removing unused variables
- Adds `setLoading(false)` as a `.finally()` to both remaining `UseEffect`s to prevent the user from being stuck on the Loading screen.